### PR TITLE
Propose: add preferWords option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ textlint --rule @textlint-ja/no-synonyms README.md
      */
     allows?: string[];
     /**
+     * 使用を許可する見出し語の配列
+     * 定義された見出し語以外の同義語をエラーにします
+     * 例) ["ユーザー"] // => 「ユーザー」だけ許可し「ユーザ」などはエラーにする
+     */
+    preferWords?: string[];
+    /**
      * 同じ語形の語の中でのアルファベットの表記揺れを許可するかどうか
      * trueの場合はカタカナとアルファベットの表記ゆれを許可します
      * 例) 「ブログ」と「blog」
@@ -80,6 +86,7 @@ textlint --rule @textlint-ja/no-synonyms README.md
     "rules": {
         "@textlint-ja/no-synonyms": {
             "allows": ["ウェブアプリ", "ウェブアプリケーション"],
+            "preferWords": ["ユーザー"],
             "allowAlphabet": false,
             "allowNumber": false
         }

--- a/src/create-index.ts
+++ b/src/create-index.ts
@@ -19,6 +19,10 @@ export class ItemGroup {
 
     }
 
+    getItem(midashi: string): SudachiSynonyms | null {
+        return this.items.find(item => item.midashi === midashi) ?? null
+    }
+
     usedItems(usedItemSet: Set<SudachiSynonyms>, { allowAlphabet, allowNumber, allows }: { allowAlphabet: boolean; allowNumber: boolean; allows: string[] }): SudachiSynonyms[] {
         // sort by used
         return Array.from(usedItemSet.values()).filter(item => {

--- a/test/textlint-rule-no-synonyms.test.ts
+++ b/test/textlint-rule-no-synonyms.test.ts
@@ -24,7 +24,14 @@ tester.run("textlint-rule-no-synonyms", rule, {
             options: {
                 allows: ["ウェブアプリ"]　// <= 片方が許可されていればOK
             }
-        }
+        },
+        // preferWords
+        {
+            text: `ユーザーだけに統一されていればユーザーは許容する`,
+            options: {
+                preferWords: ["ユーザー"]
+            }
+        },
     ],
     invalid: [{
         text: "サーバとサーバーの表記揺れがある",
@@ -58,5 +65,43 @@ tester.run("textlint-rule-no-synonyms", rule, {
                 message: "同義語である「1」と「一」が利用されています",
                 index: 5
             }]
-        }]
+        },
+        {
+            text: "ユーザーは許可しユーザはエラー。allowAlphabetがtrueならuserはエラーにならない",
+            output: "ユーザーは許可しユーザーはエラー。allowAlphabetがtrueならuserはエラーにならない",
+            options: {
+                preferWords: ["ユーザー"]
+            },
+            errors: [{
+                message: "「ユーザー」の同義語である「ユーザ」が利用されています",
+                index: 8
+            }]
+        },
+        {
+            text: "ユーザーは許可しallowAlphabetがfalseならユーザもuserもエラー",
+            output: "ユーザーは許可しallowAlphabetがfalseならユーザーもユーザーもエラー",
+            options: {
+                preferWords: ["ユーザー"],
+                allowAlphabet: false
+            },
+            errors: [{
+                message: "「ユーザー」の同義語である「ユーザ」が利用されています",
+                index: 29
+            }, {
+                message: "「ユーザー」の同義語である「user」が利用されています",
+                index: 33
+            }]
+        },
+        {
+            text: "ユーザはエラー",
+            output: "ユーザーはエラー",
+            options: {
+                preferWords: ["ユーザー"]
+            },
+            errors: [{
+                message: "「ユーザー」の同義語である「ユーザ」が利用されています",
+                index: 0
+            }]
+        },
+    ]
 });


### PR DESCRIPTION
I added an option so that users could use the same terminology throughout the documents.
We can make this a fixable rule as we know the acceptable term.

This is not a breaking change.