### PR TITLE
Propose: allowLexeme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ textlint --rule @textlint-ja/no-synonyms README.md
      * Default: true
      */
     allowNumber?: boolean;
+    /**
+     * 語彙素の異なる同義語を許可するかどうか
+     * trueの場合は語彙素の異なる同義語を許可します
+     * 例) 「ルーム」と「部屋」
+     * Default: true
+     */
+    allowLexeme?: boolean;
 }
 ```
 
@@ -88,7 +95,8 @@ textlint --rule @textlint-ja/no-synonyms README.md
             "allows": ["ウェブアプリ", "ウェブアプリケーション"],
             "preferWords": ["ユーザー"],
             "allowAlphabet": false,
-            "allowNumber": false
+            "allowNumber": false,
+            "allowLexeme": false
         }
     }
 }

--- a/test/textlint-rule-no-synonyms.test.ts
+++ b/test/textlint-rule-no-synonyms.test.ts
@@ -31,6 +31,28 @@ tester.run("textlint-rule-no-synonyms", rule, {
             options: {
                 preferWords: ["ユーザー"]
             }
+        },
+        // allowLexeme
+        {
+            text: "部屋の同義語はルームです",
+            options: {
+                allowLexeme: true
+            }
+        },
+        {
+            text: "部屋の英語はroomです",
+            options: {
+                allowLexeme: false,
+                allowAlphabet: true
+            }
+        },
+        {
+            text: "部屋の英語はroomです",
+            options: {
+                allowLexeme: false,
+                allowAlphabet: false,
+                allows: ["部屋"] // <= 片方が許可されていればOK
+            }
         }
     ],
     invalid: [
@@ -77,6 +99,31 @@ tester.run("textlint-rule-no-synonyms", rule, {
             ]
         },
         {
+            text: "部屋のカタカナ英語はルームです",
+            options: {
+                allowLexeme: false
+            },
+            errors: [
+                {
+                    message: "同義語である「部屋」と「ルーム」が利用されています",
+                    index: 10
+                }
+            ]
+        },
+        {
+            text: "部屋の英語はroomです",
+            options: {
+                allowAlphabet: false,
+                allowLexeme: false
+            },
+            errors: [
+                {
+                    message: "同義語である「部屋」と「room」が利用されています",
+                    index: 6
+                }
+            ]
+        },
+        {
             text: "ユーザーは許可しユーザはエラー。allowAlphabetがtrueならuserはエラーにならない",
             output: "ユーザーは許可しユーザーはエラー。allowAlphabetがtrueならuserはエラーにならない",
             options: {
@@ -117,6 +164,20 @@ tester.run("textlint-rule-no-synonyms", rule, {
                 {
                     message: "「ユーザー」の同義語である「ユーザ」が利用されています",
                     index: 0
+                }
+            ]
+        },
+        {
+            text: "ルームは許可しallowLexemeがfalseなら部屋もエラー",
+            output: "ルームは許可しallowLexemeがfalseならルームもエラー",
+            options: {
+                preferWords: ["ルーム"],
+                allowLexeme: false
+            },
+            errors: [
+                {
+                    message: "「ルーム」の同義語である「部屋」が利用されています",
+                    index: 26
                 }
             ]
         }


### PR DESCRIPTION
I added an option to recognize different lexeme as the same terminology. This is not a breaking change.
For example, users can use this option for these terms:

- ルーム <-> 部屋
- インターバル <-> 間隔
- セッティング <-> 設定
- 新しい <-> 新規
- サインイン <-> ログイン
- キャンセル <-> 取り消す <-> 破棄
